### PR TITLE
feat: add Docker-compatible endpoints filtering mode in Podman API

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,7 +19,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        version: ['0.4.0']
+        version: ['0.5.0']
     steps:
       - name: Check-out repository
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/golang:1.24.6 AS build
 
-ARG VERSION="0.4.0"
+ARG VERSION="0.5.0"
 
 WORKDIR /build
 
@@ -14,7 +14,7 @@ RUN go build -ldflags="-s -w \
 
 FROM cgr.dev/chainguard/wolfi-base:latest
 
-ARG VERSION="0.4.0"
+ARG VERSION="0.5.0"
 
 COPY --from=build --chown=0:0 --chmod=0755 \
   /build/peage /usr/bin/peage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The goal of this software is to remain as simple as possible by not covering all
 The easiest way to use Peage is to use the container image:
 
 ```console
-docker run -d --name peage \
+$ docker run -d --name peage \
   -p 2375:2375 -v /var/run/docker.sock:/var/run/docker.sock:ro \
   ghcr.io/f-bn/peage:0.5.0 \
     --listen-addr=:2375\

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The goal of this software is to remain as simple as possible by not covering all
 
 The easiest way to use Peage is to use the container image:
 
-```shell
+```console
 docker run -d --name peage \
   -p 2375:2375 -v /var/run/docker.sock:/var/run/docker.sock:ro \
   ghcr.io/f-bn/peage:0.5.0 \
@@ -33,14 +33,14 @@ docker run -d --name peage \
 
 Then, you can send your request (i.e with cURL):
 
-```shell
+```console
 $ curl http://localhost:2375/v1.47/_ping
 OK
 ```
 
 The request has been forwarded successfuly as it match one the allowed endpoints:
 
-```shell
+```console
 $ docker logs peage
 time=2025-08-27T15:24:13.899Z level=INFO msg="Starting Peage" version=0.5.0 commit=b19ae059 buildDate=2025-08-27_03:19:57PM
 time=2025-08-27T15:24:13.899Z level=INFO msg="Preflight checks passed"
@@ -51,8 +51,7 @@ time=2025-08-27T15:24:21.914Z level=DEBUG msg="Forwarded valid request" method=G
 
 Same goes for Podman API, you need to set some flags to correctly target the Podman API socket:
 
-```shell
-# Run the container
+```console
 $ podman run -d --name peage \
   -p 2375:2375 -v /run/podman/podman.sock:/run/podman/podman.sock:ro \
   ghcr.io/f-bn/peage:0.5.0 \
@@ -61,7 +60,6 @@ $ podman run -d --name peage \
     --socket=/run/podman/podman.sock \
     --verbose
 
-# Test a simple request
 $ curl http://localhost:2375/v5.5.2/libpod/_ping
 OK
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The goal of this software is to remain as simple as possible by not covering all
 
 ```
   -engine string
-        Container engine API used for filtering (must be 'docker' or 'podman') (default "docker")
+        Container engine API used for filtering (must be 'docker', 'podman' or 'podman-compat') (default "docker")
   -listen-addr string
         Listen address for the Peage reverse proxy server (default "localhost:2375")
   -socket string
@@ -24,14 +24,60 @@ The goal of this software is to remain as simple as possible by not covering all
 The easiest way to use Peage is to use the container image:
 
 ```shell
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/f-bn/peage:0.4.0 [flags]
+docker run -d --name peage \
+  -p 2375:2375 -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  ghcr.io/f-bn/peage:0.5.0 \
+    --listen-addr=:2375\
+    --verbose
+```
+
+Then, you can send your request (i.e with cURL):
+
+```shell
+$ curl http://localhost:2375/v1.47/_ping
+OK
+```
+
+The request has been forwarded successfuly as it match one the allowed endpoints:
+
+```shell
+$ docker logs peage
+time=2025-08-27T15:24:13.899Z level=INFO msg="Starting Peage" version=0.5.0 commit=b19ae059 buildDate=2025-08-27_03:19:57PM
+time=2025-08-27T15:24:13.899Z level=INFO msg="Preflight checks passed"
+time=2025-08-27T15:24:13.899Z level=INFO msg="Container engine API socket found" engine=docker path=/var/run/docker.sock
+time=2025-08-27T15:24:13.899Z level=INFO msg="Starting reverse proxy" address=:2375
+time=2025-08-27T15:24:21.914Z level=DEBUG msg="Forwarded valid request" method=GET path=/v1.47/_ping client=curl/8.12.1
+```
+
+Same goes for Podman API, you need to set some flags to correctly target the Podman API socket:
+
+```shell
+# Run the container
+$ podman run -d --name peage \
+  -p 2375:2375 -v /run/podman/podman.sock:/run/podman/podman.sock:ro \
+  ghcr.io/f-bn/peage:0.5.0 \
+    --listen-addr=:2375 \
+    --engine=podman \
+    --socket=/run/podman/podman.sock \
+    --verbose
+
+# Test a simple request
+$ curl http://localhost:2375/v5.5.2/libpod/_ping
+OK
+
+$ podman logs peage
+time=2025-08-27T15:27:13.341Z level=INFO msg="Starting Peage" version=0.5.0 commit=b19ae059 buildDate=2025-08-27_03:19:57PM
+time=2025-08-27T15:27:13.341Z level=INFO msg="Preflight checks passed"
+time=2025-08-27T15:27:13.341Z level=INFO msg="Container engine API socket found" engine=podman path=/run/podman/podman.sock
+time=2025-08-27T15:27:13.341Z level=INFO msg="Starting reverse proxy" address=:2375
+time=2025-08-27T15:27:35.688Z level=DEBUG msg="Forwarded valid request" method=GET path=/v5.5.2/libpod/_ping client=curl/8.12.1
 ```
 
 ### Allowed endpoints
 
-Peage only allows calls using the `GET` or `HEAD` method on specific **hardcoded** paths depending of the choosen engine:
+Peage only allows calls using the `GET` or `HEAD` method on specific **hardcoded** paths depending of the choosen engine filtering mode:
 
-**Docker**
+**Docker (docker)**
 
   - `/containers/json`
   - `/containers/*/json`
@@ -45,7 +91,7 @@ Peage only allows calls using the `GET` or `HEAD` method on specific **hardcoded
   - `/volumes/<name>`
   - `/_ping`
 
-**Podman**
+**Podman (podman)**
 
   - `/libpod/containers/json`
   - `/libpod/containers/stats`
@@ -64,7 +110,11 @@ Peage only allows calls using the `GET` or `HEAD` method on specific **hardcoded
   - `/libpod/volumes/json`
   - `/libpod/volumes/*/(json|exists)`
 
-Note: Podman API filtering is only done on libpod 5.0.0+ API paths (Docker-compatible API paths are not allowed, use the `docker` filtering mode for this)
+**Podman with Docker-compatible endpoints (podman-compat)**
+
+This engine mode enable both Docker and Podman API filtering. This is useful if you want to have a single proxy on top of Podman API to handle both Docker-compatible and dedicated Podman endpoints.
+
+For example, if you have apps that only know about Docker API (i.e Traefik) and some others only about Podman API (i.e Prometheus Podman Exporter), then it is easier to manage with a single proxy instead of having to deploy one for each filtering mode.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Peage only allows calls using the `GET` or `HEAD` method on specific **hardcoded
 **Docker (docker)**
 
   - `/containers/json`
-  - `/containers/*/json`
+  - `/containers/*/(json|stats)`
   - `/events`
   - `/images/json`
   - `/images/*/json`

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ var (
 
 var dockerAllowedPaths = []string{
 	"^/containers/json$",
-	"^/containers/[^/]+/json$",
+	"^/containers/[^/]+/(json|stats)$",
 	"^/events$",
 	"^/images/json$",
 	"^/images/[^/]+/json$",

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httputil"
 	"os"
 	"regexp"
+	"slices"
 )
 
 // Version
@@ -70,13 +71,13 @@ var podmanAllowedPaths = []string{
 func init() {
 	flag.StringVar(&listenAddress, "listen-addr", "localhost:2375", "Listen address for the Peage reverse proxy server")
 	flag.StringVar(&socketPath, "socket", "/var/run/docker.sock", "Path to the container engine API UNIX socket")
-	flag.StringVar(&containerEngine, "engine", "docker", "Container engine API used for filtering (must be 'docker' or 'podman')")
+	flag.StringVar(&containerEngine, "engine", "docker", "Container engine API used for filtering (must be 'docker', 'podman', or 'podman-compat')")
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging of requests")
 }
 
 func runPreflightChecks() error {
 	if !isValidContainerEngine(containerEngine) {
-		return fmt.Errorf("invalid container engine '%s' (must be 'docker' or 'podman')", containerEngine)
+		return fmt.Errorf("invalid container engine '%s' (must be 'docker', 'podman', or 'podman-compat')", containerEngine)
 	}
 	if err := checkSocketPathExists(socketPath); err != nil {
 		return fmt.Errorf("socket path check failed: %w", err)
@@ -94,7 +95,7 @@ func getEngineVersionPattern(engine string) string {
 	switch engine {
 	case "docker":
 		return `^/v\d+\.\d+`
-	case "podman":
+	case "podman", "podman-compat":
 		return `^/v\d+\.\d+(\.\d+)?`
 	default:
 		return ""
@@ -107,6 +108,8 @@ func getEngineAllowedPaths(engine string) []string {
 		return dockerAllowedPaths
 	case "podman":
 		return podmanAllowedPaths
+	case "podman-compat":
+		return slices.Concat(dockerAllowedPaths, podmanAllowedPaths)
 	default:
 		return nil
 	}
@@ -120,7 +123,12 @@ func checkSocketPathExists(path string) error {
 }
 
 func isValidContainerEngine(engine string) bool {
-	return engine == "docker" || engine == "podman"
+	validEngines := []string{
+		"docker",
+		"podman",
+		"podman-compat",
+	}
+	return slices.Contains(validEngines, engine)
 }
 
 func isAllowedPath(path string) bool {


### PR DESCRIPTION
This engine mode enable both Docker and Podman API filtering. This is useful if you want to have a single proxy on top of Podman API to handle both Docker-compatible and dedicated Podman endpoints.

\+ add a fix for a missing Docker endpoints for containers stats